### PR TITLE
Update GH workflow

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -3,7 +3,7 @@ name: deploy-dev
 on:
   workflow_run:
     workflows:
-      - check
+      - pre-deploy-check
     types:
       - completed
     branches:

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -3,7 +3,7 @@ name: deploy-prod
 on:
   workflow_run:
     workflows:
-      - check
+      - pre-deploy-check
     types:
       - completed
     branches:

--- a/.github/workflows/deploy-stage.yaml
+++ b/.github/workflows/deploy-stage.yaml
@@ -3,7 +3,7 @@ name: deploy-stage
 on:
   workflow_run:
     workflows:
-      - check
+      - pre-deploy-check
     types:
       - completed
     branches:

--- a/.github/workflows/pre-deploy-check.yml
+++ b/.github/workflows/pre-deploy-check.yml
@@ -1,0 +1,25 @@
+name: pre-deploy-check
+
+on:
+  workflow_run:
+    workflows:
+      - check
+    types:
+      - completed
+    branches: [dev, stage, prod]
+
+jobs:
+  synth:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: pip install -r requirements.txt -r requirements-dev.txt
+      - name: Generate cloudformation
+        uses: youyo/aws-cdk-github-actions@v2
+        with:
+          cdk_subcommand: 'synth'
+          actions_comment: false
+          debug_log: true
+          cdk_args: '--output ./cdk.out'


### PR DESCRIPTION
Secrets are now resolved in code therefore we can no longer run synth check on a PR because synth requires access to AWS. Refactor GH workflow to run a synth check on a pre-deployment check.

