### PR TITLE
Simplify the github workflow

### DIFF
--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -24,7 +24,7 @@ on:
       environment:
         required: true
         type: string
-        default: "dev"
+        default: ${{ github.ref_name }}
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -15,4 +15,3 @@ jobs:
     with:
       role-to-assume: "arn:aws:iam::631692904429:role/sagebase-github-oidc-sage-bionetworks-schematic-infra"
       role-session-name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
-      environment: "dev"

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -15,4 +15,3 @@ jobs:
     with:
       role-to-assume: "arn:aws:iam::878654265857:role/sagebase-github-oidc-sage-bionetworks-schematic-infra"
       role-session-name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
-      environment: "prod"

--- a/.github/workflows/deploy-stage.yaml
+++ b/.github/workflows/deploy-stage.yaml
@@ -15,4 +15,3 @@ jobs:
     with:
       role-to-assume: "arn:aws:iam::878654265857:role/sagebase-github-oidc-sage-bionetworks-schematic-infra"
       role-session-name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
-      environment: "stage"


### PR DESCRIPTION
Instead of hard coding the branch name for deployments we can dynamically get it using ${{ github.ref_name }}.  This simplifies the workflow assuming that we match our branch name to deployment environments.
