### PR TITLE
[IT-3975] Deploy opentelemetry collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ Schematic has been instrumented with a mix of
 [automationally instrumented libraries](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation)
 and [manual traces](https://opentelemetry-python.readthedocs.io/en/latest/api/trace.html).
 In addition it's been configured at startup to [conditionally turn on trace/log exports](https://github.com/Sage-Bionetworks/schematic/blob/778bf54db9c5b4de0af334c4efe034b3dde0b348/schematic/__init__.py#L82-L139)
-depending on how a few environment variables are set. The combination of all these lets
+depending on how a few environment variables are set. The combination of these items let
 the schematic container running in ECS export telemetry data out of the container to be
 ingested somewhere else for long-term storage.
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,6 @@ app_service_props = ServiceProps(
     container_port=443,
     container_memory=1024,
     container_location="ghcr.io/sage-bionetworks/app:v1.0",
-    container_env_vars={},
     container_secrets=[
         ServiceSecret(
             secret_name="app/dev/DATABASE",

--- a/app.py
+++ b/app.py
@@ -109,7 +109,6 @@ app_service_props_otel_collector = ServiceProps(
     container_port=4318,
     container_memory=512,
     container_location="ghcr.io/sage-bionetworks/sage-otel-collector:v0.0.4",
-    container_env_vars={},
     container_secrets=[
         ServiceSecret(
             secret_name=f"{stack_name_prefix}-DockerFargateStack/{environment}/opentelemetry-collector-configuration",

--- a/app.py
+++ b/app.py
@@ -108,7 +108,7 @@ app_service_props_otel_collector = ServiceProps(
     container_name="otel-collector",
     container_port=4318,
     container_memory=512,
-    container_location="ghcr.io/sage-bionetworks/sage-otel-collector:v0.0.4",
+    container_location="ghcr.io/sage-bionetworks/sage-otel-collector:0.0.1",
     container_secrets=[
         ServiceSecret(
             secret_name=f"{stack_name_prefix}-DockerFargateStack/{environment}/opentelemetry-collector-configuration",

--- a/app.py
+++ b/app.py
@@ -1,11 +1,12 @@
+from os import environ
+
 import aws_cdk as cdk
 
-from os import environ
-from src.network_stack import NetworkStack
 from src.ecs_stack import EcsStack
-from src.service_stack import LoadBalancedServiceStack
 from src.load_balancer_stack import LoadBalancerStack
-from src.service_props import ServiceProps
+from src.network_stack import NetworkStack
+from src.service_props import ServiceProps, ServiceSecret
+from src.service_stack import LoadBalancedServiceStack, ServiceStack
 
 # get the environment and set environment specific variables
 VALID_ENVIRONMENTS = ["dev", "stage", "prod"]
@@ -35,7 +36,7 @@ match environment:
     case _:
         valid_envs_str = ",".join(VALID_ENVIRONMENTS)
         raise SystemExit(
-            f"Must set environment variable `ENV` to one of {valid_envs_str}"
+            f"Must set environment variable `ENV` to one of {valid_envs_str}. Currently set to {environment}."
         )
 
 stack_name_prefix = f"schematic-{environment}"
@@ -68,12 +69,27 @@ load_balancer_stack = LoadBalancerStack(
     cdk_app, f"{stack_name_prefix}-load-balancer", network_stack.vpc
 )
 
+telemetry_environment_variables = {
+    "TRACING_EXPORT_FORMAT": "otlp",
+    "LOGGING_EXPORT_FORMAT": "otlp",
+    "TRACING_SERVICE_NAME": "schematic",
+    "LOGGING_SERVICE_NAME": "schematic",
+    "DEPLOYMENT_ENVIRONMENT": environment,
+    "OTEL_EXPORTER_OTLP_ENDPOINT": "http://otel-collector:4318",
+}
+
 app_service_props = ServiceProps(
-    "schematic-app",
-    "ghcr.io/sage-bionetworks/schematic:v0.1.90-beta",
-    443,
+    container_name="schematic-app",
+    container_location="ghcr.io/sage-bionetworks/schematic:v0.1.94-beta",
+    container_port=443,
     container_memory=1024,
-    container_secret_name=f"{stack_name_prefix}-DockerFargateStack/{environment}/ecs",
+    container_env_vars=telemetry_environment_variables,
+    container_secrets=[
+        ServiceSecret(
+            secret_name=f"{stack_name_prefix}-DockerFargateStack/{environment}/ecs",
+            environment_key="SECRETS_MANAGER_SECRETS",
+        )
+    ],
 )
 
 app_service_stack = LoadBalancedServiceStack(
@@ -88,5 +104,28 @@ app_service_stack = LoadBalancedServiceStack(
     health_check_interval=5,
 )
 
-# Generate stacks
+app_service_props_otel_collector = ServiceProps(
+    container_name="otel-collector",
+    container_port=4318,
+    container_memory=512,
+    container_location="ghcr.io/sage-bionetworks/sage-otel-collector:v0.0.4",
+    container_env_vars={},
+    container_secrets=[
+        ServiceSecret(
+            secret_name=f"{stack_name_prefix}-DockerFargateStack/{environment}/opentelemetry-collector-configuration",
+            environment_key="CONFIG_CONTENT",
+        )
+    ],
+    container_command=["--config", "env:CONFIG_CONTENT"],
+    container_healthcheck=cdk.aws_ecs.HealthCheck(command=["CMD", "/healthcheck"]),
+)
+
+app_service_stack_otel_collector = ServiceStack(
+    scope=cdk_app,
+    construct_id=f"{stack_name_prefix}-otel-collector",
+    vpc=network_stack.vpc,
+    cluster=ecs_stack.cluster,
+    props=app_service_props_otel_collector,
+)
+
 cdk_app.synth()


### PR DESCRIPTION
**Problem:**

1. An Opentelemetry collector needs to be deployed to ECS to support forwarding telemetry data for long-term storage and analysis.
2. A configuration file for the collector needs to be sourced from AWS secrets manager and injected into the Otel collector to configure the service.
3. Environment variables need to be updated in the schematic container to support configuring it to send telemetry data to the Otel collector.
4. A container level health check is needed as this service is not fronted by a load balancer.

**Solution:**

1. Deploying the otel collector contributor container to ECS. I had attempted to use the AWS otel collector, however, they do not support the Oauth2 extension that we will use to attached an Auth header on out-going requests: https://github.com/aws-observability/aws-otel-collector/issues/1492
2. Storing the otel config file in AWS Secret manager and injecting it into the Otel collector by overriding the docker CMD command on the container.
3. Setting environment variables on the schematic container to configure it sending telemetry data to the otel collector.
4. Pointing to our sage specific docker image that contains a binary compiled from golang that does container level health checks.

**Testing:**

1. I verified that I was able to deploy both schematic and the otel collector to AWS ECS.
2. I verified that by setting the environment variables in schematic that it was able to produce, and forward it's data to the otel collector.
3. I verified that the otel collector was able to perform the oauth2 client credential exchange with Auth0 to obtain an access token.
4. I verified that both logs AND traces were forwarded to the kubernetes cluster/SigNoz and ingested into Clickhouse for long-term storage.
5. I verified that the telemetry data showed up in the SigNoz UI as expected.