### PR TITLE
Fix environment in CI workflow

### DIFF
--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -22,8 +22,8 @@ on:
         type: number
         default: 3600
       environment:
+        required: true
         type: string
-        default: ${{ github.ref_name }}
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -15,3 +15,4 @@ jobs:
     with:
       role-to-assume: "arn:aws:iam::631692904429:role/sagebase-github-oidc-sage-bionetworks-it-schematic-infra-v2"
       role-session-name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+      environment: dev

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -15,3 +15,4 @@ jobs:
     with:
       role-to-assume: "arn:aws:iam::878654265857:role/sagebase-github-oidc-sage-bionetworks-it-schematic-infra-v2"
       role-session-name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+      environment: prod

--- a/.github/workflows/deploy-stage.yaml
+++ b/.github/workflows/deploy-stage.yaml
@@ -15,3 +15,4 @@ jobs:
     with:
       role-to-assume: "arn:aws:iam::878654265857:role/sagebase-github-oidc-sage-bionetworks-it-schematic-infra-v2"
       role-session-name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+      environment: stage


### PR DESCRIPTION
The github.ref_name reference is not reliable for getting the branch name. When pushing a `stage` branch that reference sets the environment to `dev`.

We change to explicitly pass in the correct enviornment for each workflow.

