### PR TITLE
Bumping resources closer to current deployment

### DIFF
--- a/app.py
+++ b/app.py
@@ -26,7 +26,7 @@ match environment:
             "FQDN": "stage.schematic.io",
             "CERTIFICATE_ARN": "arn:aws:acm:us-east-1:878654265857:certificate/d11fba3c-1957-48ba-9be0-8b1f460ee970",
             "TAGS": {"CostCenter": "NO PROGRAM / 000000"},
-            "SCHEMATIC_CONTAINER_LOCATION": "ghcr.io/sage-bionetworks/schematic:v0.1.94-beta",
+            "SCHEMATIC_CONTAINER_LOCATION": "ghcr.io/sage-bionetworks/schematic:v24.11.2-rc",
         }
     case "dev":
         environment_variables = {
@@ -34,7 +34,7 @@ match environment:
             "FQDN": "dev.schematic.io",
             "CERTIFICATE_ARN": "arn:aws:acm:us-east-1:631692904429:certificate/0e9682f6-3ffa-46fb-9671-b6349f5164d6",
             "TAGS": {"CostCenter": "NO PROGRAM / 000000"},
-            "SCHEMATIC_CONTAINER_LOCATION": "ghcr.io/sage-bionetworks/schematic:v0.1.94-beta",
+            "SCHEMATIC_CONTAINER_LOCATION": "ghcr.io/sage-bionetworks/schematic:v24.11.2-rc",
         }
     case _:
         valid_envs_str = ",".join(VALID_ENVIRONMENTS)

--- a/src/load_balancer_stack.py
+++ b/src/load_balancer_stack.py
@@ -14,11 +14,20 @@ class LoadBalancerStack(cdk.Stack):
     """
 
     def __init__(
-        self, scope: Construct, construct_id: str, vpc: ec2.Vpc, **kwargs
+        self,
+        scope: Construct,
+        construct_id: str,
+        vpc: ec2.Vpc,
+        idle_timeout_seconds: int,
+        **kwargs
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
         self.alb = elbv2.ApplicationLoadBalancer(
-            self, "AppLoadBalancer", vpc=vpc, internet_facing=True
+            self,
+            "AppLoadBalancer",
+            vpc=vpc,
+            idle_timeout=cdk.Duration.seconds(idle_timeout_seconds),
+            internet_facing=True,
         )
         cdk.CfnOutput(self, "dns", value=self.alb.load_balancer_dns_name)


### PR DESCRIPTION
**Problem:**

1. The current schematic deployment sets a CPU of 4096, and memory of 8198. From information that Khai pulled from cloud watch insights we are only getting to around 40% memory, and less than half in CPU.
2. The current schematic deployment scaled between 3 and 5 instances.
3. Current deployment sets and `idle_timeout` of 300 seconds on the ALB


**Solution:**

1. Bumping cpu/memory limits up from what they were, but not as high as the current deployment.
2. Update scaling for the schematic container
3. Adding the `idle_timeout` to the ALB

**Testing:**

1. Will test deployment in dev environment