### PR TITLE
Fix cloudformation load balancer ouput

### DIFF
--- a/src/load_balancer_stack.py
+++ b/src/load_balancer_stack.py
@@ -19,7 +19,7 @@ class LoadBalancerStack(cdk.Stack):
         construct_id: str,
         vpc: ec2.Vpc,
         idle_timeout_seconds: int,
-        **kwargs
+        **kwargs,
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
@@ -30,4 +30,6 @@ class LoadBalancerStack(cdk.Stack):
             idle_timeout=cdk.Duration.seconds(idle_timeout_seconds),
             internet_facing=True,
         )
-        cdk.CfnOutput(self, "dns", value=self.alb.load_balancer_dns_name)
+        cdk.CfnOutput(
+            self, f"{construct_id}-dns", value=self.alb.load_balancer_dns_name
+        )


### PR DESCRIPTION
We depend on the cloudformation's load balancer exported DNS endpoint to configure a DNS redirect in organizations-infra repo[1].  The export name needs to be unique in the account.

[1] https://github.com/Sage-Bionetworks-IT/organizations-infra/blob/master/org-formation/800-redirects/_tasks.yaml

