### PR TITLE
Fix cloudformation ouput

### DIFF
--- a/src/load_balancer_stack.py
+++ b/src/load_balancer_stack.py
@@ -31,5 +31,8 @@ class LoadBalancerStack(cdk.Stack):
             internet_facing=True,
         )
         cdk.CfnOutput(
-            self, f"{construct_id}-dns", value=self.alb.load_balancer_dns_name
+            self,
+            "LoadBalancerDns",
+            value=self.alb.load_balancer_dns_name,
+            export_name=f"{construct_id}-dns",
         )

--- a/src/load_balancer_stack.py
+++ b/src/load_balancer_stack.py
@@ -34,5 +34,5 @@ class LoadBalancerStack(cdk.Stack):
             self,
             "LoadBalancerDns",
             value=self.alb.load_balancer_dns_name,
-            export_name=f"{construct_id}-dns",
+            export_name=f"{construct_id}-load-balancer-dns",
         )


### PR DESCRIPTION
The fix in commit 5abc77f, was incorrect.  We need to set the export name, not the resource name.  Trying again.


