### PR TITLE
[IT-3951] Fix guardduty container

### DIFF
--- a/src/service_stack.py
+++ b/src/service_stack.py
@@ -57,6 +57,28 @@ class ServiceStack(cdk.Stack):
             )
         )
 
+        # default ECS execution policy plus Guardduty access
+        execution_role = iam.Role(
+            self,
+            "ExecutionRole",
+            assumed_by=iam.ServicePrincipal("ecs-tasks.amazonaws.com"),
+            managed_policies=[
+                iam.ManagedPolicy.from_aws_managed_policy_name(
+                    "service-role/AmazonECSTaskExecutionRolePolicy"
+                ),
+            ],
+        )
+        execution_role.add_to_policy(
+            iam.PolicyStatement(
+                actions=[
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents",
+                ],
+                resources=["*"],
+                effect=iam.Effect.ALLOW,
+            )
+        )
+
         # ECS task with fargate
         self.task_definition = ecs.FargateTaskDefinition(
             self,
@@ -64,6 +86,7 @@ class ServiceStack(cdk.Stack):
             cpu=1024,
             memory_limit_mib=4096,
             task_role=task_role,
+            execution_role=execution_role,
         )
 
         image = ecs.ContainerImage.from_registry(props.container_location)


### PR DESCRIPTION
We enable guardduty security monitoring for ECS in every account. For that to work we need to give Fargate tasks access to do ECS stuff with the service-role/AmazonECSTaskExecutionRolePolicy[1].

[1] https://docs.aws.amazon.com/guardduty/latest/ug/prereq-runtime-monitoring-ecs-support.html#before-enable-runtime-monitoring-ecs

