### PR TITLE
Add environment to pull correct branch during action run

### DIFF
--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.environment }}
       - name: Install AWS CLI
         run: sudo snap install aws-cli --classic
       - name: Install AWS CDK CLI


### PR DESCRIPTION
Problem:

1. From what @ConsoleCatzirl found:

> it looks like [the action will checkout the git ref for the event](https://github.com/actions/checkout/tree/v3?tab=readme-ov-file#checkout-v3) and for workflow_run events [the git ref is the default branch](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run)


Solution:

1. Set ref to environment which matches the name of the branches we use in this repo
2. Syntax for this section of the action: https://github.com/actions/checkout/tree/v3?tab=readme-ov-file#checkout-a-different-branch

Testing:

1. Will verify in next action run